### PR TITLE
Add deployments/zeabur.md

### DIFF
--- a/deployments/zeabur.md
+++ b/deployments/zeabur.md
@@ -1,0 +1,11 @@
+# Zeabur One Click Deployment
+
+You can quickly setup a sample Zeabur CodiMD application by clicking the button below.
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/TAZC8W)
+
+A simple video of how to deploy CodiMD with Zeabur One Click Deployment [is available here](https://videos.zeabur.com/codimd.mp4).
+
+If you want to deploy it without the button, you can deploy it by creating the PostgreSQL and [CodiMD](https://zeabur.com/docs/zh-TW/marketplace/postgresql) services with Zeabur Prebuilt Marketplace.
+
+###### tags: `CodiMD` `Docs`

--- a/deployments/zeabur.md
+++ b/deployments/zeabur.md
@@ -6,6 +6,6 @@ You can quickly setup a sample Zeabur CodiMD application by clicking the button 
 
 A simple video of how to deploy CodiMD with Zeabur One Click Deployment [is available here](https://videos.zeabur.com/codimd.mp4).
 
-If you want to deploy it without the button, you can deploy it by creating the PostgreSQL and [CodiMD](https://zeabur.com/docs/zh-TW/marketplace/postgresql) services with Zeabur Prebuilt Marketplace.
+If you want to deploy it without the button, you can deploy it by creating the [PostgreSQL](https://zeabur.com/docs/zh-TW/marketplace/postgresql) and CodiMD services with Zeabur Prebuilt Marketplace.
 
 ###### tags: `CodiMD` `Docs`


### PR DESCRIPTION
# Zeabur One Click Deployment

 You can quickly setup a sample Zeabur CodiMD application by clicking the button below.

 [![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/TAZC8W)

 A simple video of how to deploy CodiMD with Zeabur One Click Deployment [is available here](https://videos.zeabur.com/codimd.mp4).

https://github.com/hackmdio/codimd-docs/assets/28441561/23766d68-402d-431c-bc2e-73ecd4481799

If you want to deploy it without the button, you can deploy it by creating the [PostgreSQL](https://zeabur.com/docs/zh-TW/marketplace/postgresql) and CodiMD services with Zeabur Prebuilt Marketplace.

 ###### tags: `CodiMD` `Docs`